### PR TITLE
feat: 0.1.5 Greatly improved performance, avoid usage of deprecated symbols, bump esox to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [0.1.5] - Unreleased
+## [0.1.5] - 2026-05-15
+
+### Added
+
+- Add `lessclone` feature, enabled by default
+  - Improves performance significantly
 
 ### Changed
 
@@ -8,6 +13,9 @@
 - Avoid usage of deprecated fields
   - `esox::domani::niseci::ComunitaNISECI`
 - Bump `esox` to `0.1.6`
+  - Improves performance for all builds
+  - More improvements when building with `lessclone` feature
+  - Changelog: [link](https://github.com/JGGR/esox/releases/tag/0.1.6)
 
 ## [0.1.4] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.1.5] - Unreleased
+
+### Changed
+
+- Avoid usage of deprecated reexports
+  - `esox::domani::niseci::ValoriIntermediNISECI::to_csv` -> `esox::domani::niseci::ValoriIntermediNISECI::to_csv_joined`
+  - `esox::domani::niseci::ValoriIntermediNISECI::log`
+- Bump `esox` to `0.1.6`
+
 ## [0.1.4] - 2026-04-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Avoid usage of deprecated reexports
   - `esox::domani::niseci::ValoriIntermediNISECI::to_csv` -> `esox::domani::niseci::ValoriIntermediNISECI::to_csv_joined`
   - `esox::domani::niseci::ValoriIntermediNISECI::log`
+- Avoid usage of deprecated fields
+  - `esox::domani::niseci::ComunitaNISECI`
 - Bump `esox` to `0.1.6`
 
 ## [0.1.4] - 2026-04-30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,18 +259,19 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "esox"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4496c8b7bb2ef98775837fd6823d4d743528efaf0d9687007ded3082d92da40f"
+checksum = "c2a264c149e5fa15ac77b008f27f03fd8aed6a7f9eb2c029d8007dd9626fe9ca"
 dependencies = [
  "chrono",
  "csv",
+ "hashbrown 0.17.1",
  "serde",
 ]
 
 [[package]]
 name = "f_value"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "dirs",
@@ -308,6 +309,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "gdk-pixbuf-sys"
@@ -436,7 +443,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -444,6 +451,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "f_value"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Tool for NISECI and HFBI calc"
 license = "GPL-3.0-only"
@@ -22,7 +22,7 @@ chrono = "0.4.39"
 [dependencies]
 chrono = "0.4.44"
 dirs = "6.0.0"
-esox = "0.1.5"
+esox = "0.1.6"
 locale_config = "0.3.0"
 miniz_oxide = "0.9.1"
 pdf-writer = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ exclude = [
 ]
 
 [features]
-default = ["embed-icon", "rfd-xdg-portal"]
+default = ["embed-icon", "lessclone", "rfd-xdg-portal"]
 embed-icon = []
-rfd-gtk3 = [ "rfd/gtk3" ]
-rfd-xdg-portal = [ "rfd/xdg-portal" ]
+lessclone = ["esox/lessclone"]
+rfd-gtk3 = ["rfd/gtk3"]
+rfd-xdg-portal = ["rfd/xdg-portal"]
 
 [build-dependencies]
 chrono = "0.4.39"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/JGGR/F-value/master/assets/logo.png" alt="F-Value" width="240">
+</p>
+
 # F-value
 
 ## Tool for NISECI and HFBI calc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/JGGR/F-value/master/assets/logo.png" alt="F-Value" width="240">
+  <img src="https://raw.githubusercontent.com/JGGR/F-value/master/assets/logo.png" alt="F-Value" width="240" align="middle" />&nbsp;&nbsp;&nbsp;
+  <img src="https://raw.githubusercontent.com/JGGR/F-value/master/assets/logo_name.png" alt="" align="middle" />
 </p>
 
 # F-value

--- a/build.rs
+++ b/build.rs
@@ -74,6 +74,18 @@ fn main() {
         "gtk3"
     };
     println!("cargo:rustc-env=RFD_BACKEND={}", rfd_backend);
+
+    let use_lessclone = std::env::var("CARGO_FEATURE_LESSCLONE").is_ok();
+    let esox_lessclone_backend = if use_lessclone {
+        "v0.2-dev (lessclone)"
+    } else {
+        "v0.1"
+    };
+    println!(
+        "cargo:rustc-env=ESOX_LESSCLONE_BACKEND={}",
+        esox_lessclone_backend
+    );
+
     let pkg_name = env!("CARGO_PKG_NAME");
     let pkg_version = env!("CARGO_PKG_VERSION");
     let branch_name = get_branch_name();

--- a/src/app/model/mod.rs
+++ b/src/app/model/mod.rs
@@ -19,11 +19,20 @@ use crate::console::Console;
 use crate::core::SHORT_PROJECT_VERSION;
 use esox::domain::hfbi::{AnagraficaHFBI, CampionamentoHFBI, RisultatoHFBI, StatoEcologicoHFBI};
 use esox::domain::index::Indice;
-use esox::domain::niseci::{
-    AnagraficaNISECI, CampionamentoNISECI, RiferimentoNISECI, RisultatoNISECI, StatoEcologicoNISECI,
+use esox::domain::niseci::{AnagraficaNISECI, RiferimentoNISECI, StatoEcologicoNISECI};
+#[cfg(not(feature = "lessclone"))]
+use esox::{
+    domain::niseci::{CampionamentoNISECI, RisultatoNISECI},
+    engines::niseci::full::calculate_stato_ecologico_niseci,
 };
+
+#[cfg(feature = "lessclone")]
+use esox::{
+    domain::niseci::lessclone::{CampionamentoNISECI, RisultatoNISECI},
+    engines::niseci::full::lessclone::calculate_stato_ecologico_niseci,
+};
+
 use esox::engines::hfbi::full::calculate_stato_ecologico_hfbi;
-use esox::engines::niseci::full::calculate_stato_ecologico_niseci;
 use std::collections::HashMap;
 use std::path::PathBuf;
 

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -222,12 +222,6 @@ pub(crate) fn draw_info_box(
             default_txt_spacing as f32,
         );
         //let proj_info_str_y = propheight(&d, 100) - current_font_height / 2;
-        let esox_info_str = format!("Using esox {}", esox::meta::version());
-        let esox_info_txt_bounds = font.measure_text(
-            &esox_info_str,
-            current_font_height as f32,
-            default_txt_spacing as f32,
-        );
 
         // No multiline text.
         let proj_name_str1 = "Strumento per il calcolo".to_string();
@@ -260,7 +254,6 @@ pub(crate) fn draw_info_box(
 
         let infobox_height = propheight(d, 200)
             + proj_info_txt_bounds.y as i32
-            + esox_info_txt_bounds.y as i32
             + proj_name_str1_txt_bounds.y as i32
             + proj_name_str2_txt_bounds.y as i32;
         let infobox_y = d.get_screen_height() / 2 - infobox_height / 2;
@@ -275,10 +268,8 @@ pub(crate) fn draw_info_box(
         let text_x_spacing = propwidth(d, 120);
         let proj_info_str_y = infobox_y + bar_height + text_y_spacing;
         let proj_info_str_x = infobox_x + text_x_spacing;
-        let esox_info_str_y = proj_info_str_y + proj_info_txt_bounds.y as i32;
-        let esox_info_str_x = proj_info_str_x;
-        let proj_name_str1_y = esox_info_str_y + (esox_info_txt_bounds.y as i32 * 2);
-        let proj_name_str1_x = esox_info_str_x;
+        let proj_name_str1_y = proj_info_str_y + proj_info_txt_bounds.y as i32;
+        let proj_name_str1_x = proj_info_str_x;
         let proj_name_str2_y = proj_name_str1_y + proj_name_str1_txt_bounds.y as i32;
         let proj_name_str2_x = proj_name_str1_x;
 
@@ -286,15 +277,6 @@ pub(crate) fn draw_info_box(
             font,
             &proj_info_str,
             Vector2::new(proj_info_str_x as f32, proj_info_str_y as f32),
-            current_font_height as f32,
-            default_txt_spacing as f32,
-            default_txt_color,
-        );
-
-        d.draw_text_ex(
-            font,
-            &esox_info_str,
-            Vector2::new(esox_info_str_x as f32, esox_info_str_y as f32),
             current_font_height as f32,
             default_txt_spacing as f32,
             default_txt_color,
@@ -359,14 +341,39 @@ pub(crate) fn draw_info_box(
             raylib::core::misc::open_url(actual_link);
         }
 
+        let using_esox_display_link = &format!("esox v{}", esox::meta::version());
+        let using_esox_actual_link = "https://github.com/JGGR/esox";
+        let esox_link_str = using_esox_display_link;
+        let esox_link_x = link_x;
+        let esox_link_y = link_y + link_height;
+        let esox_link_width = link_width;
+        let esox_link_height = link_height;
+
+        d.gui_label(
+            rrect(
+                infobox_x + propwidth(d, 10),
+                esox_link_y,
+                text_x_spacing,
+                esox_link_height,
+            ),
+            "Using:",
+        );
+
+        if d.gui_label_button(
+            rrect(esox_link_x, esox_link_y, esox_link_width, esox_link_height),
+            esox_link_str,
+        ) {
+            raylib::core::misc::open_url(using_esox_actual_link);
+        }
+
         let support_email = "a.marchi@hsbologna.it";
         let mail_display_link = support_email.to_owned();
         let mail_actual_link = "mailto:".to_owned() + support_email;
         let mail_link_str = mail_display_link;
-        let mail_link_x = link_x;
-        let mail_link_y = link_y + link_height;
-        let mail_link_width = link_width;
-        let mail_link_height = link_height;
+        let mail_link_x = esox_link_x;
+        let mail_link_y = esox_link_y + esox_link_height;
+        let mail_link_width = esox_link_width;
+        let mail_link_height = esox_link_height;
 
         d.gui_label(
             rrect(

--- a/src/controllers/file_input.rs
+++ b/src/controllers/file_input.rs
@@ -28,7 +28,13 @@ use esox::csv::stanis::giorgio::format_csv_errors;
 use esox::deser::TipoRecord;
 use esox::domain::hfbi::CampionamentoHFBI;
 use esox::domain::index::Indice;
-use esox::domain::niseci::{CampionamentoNISECI, RiferimentoNISECI};
+use esox::domain::niseci::RiferimentoNISECI;
+
+#[cfg(feature = "lessclone")]
+use esox::domain::niseci::lessclone::CampionamentoNISECI;
+#[cfg(not(feature = "lessclone"))]
+use esox::domain::niseci::CampionamentoNISECI;
+
 use raylib::RaylibHandle;
 use std::path::PathBuf;
 

--- a/src/controllers/info_aggiuntive.rs
+++ b/src/controllers/info_aggiuntive.rs
@@ -361,9 +361,9 @@ impl InfoAggiuntiveController {
                 ));
             }
 
-            match anagrafica.comunita.tipo {
+            match anagrafica.comunita.tipo() {
                 TipoComunitaNISECI::Recuperata => {
-                    if let Some(fonte) = anagrafica.comunita.fonte {
+                    if let Some(fonte) = anagrafica.comunita.fonte() {
                         if fonte.is_empty() {
                             errors.push("Fonte troppo corta".to_string());
                         }
@@ -372,7 +372,7 @@ impl InfoAggiuntiveController {
                     }
                 }
                 TipoComunitaNISECI::AffinataDalMase => {
-                    if let Some(num_proto) = anagrafica.comunita.numero_protocollo {
+                    if let Some(num_proto) = anagrafica.comunita.num_protocollo() {
                         if num_proto.is_empty() {
                             errors.push("Numero protocollo troppo corto".to_string());
                         }

--- a/src/controllers/output.rs
+++ b/src/controllers/output.rs
@@ -24,7 +24,9 @@ use crate::MainState;
 use dirs::document_dir;
 use esox::domain::hfbi::{AnagraficaHFBI, RisultatoHFBI, ValoriIntermediHFBI};
 use esox::domain::index::Indice;
-use esox::domain::niseci::{AnagraficaNISECI, RisultatoNISECI, ValoriIntermediNISECI};
+use esox::domain::niseci::{
+    AnagraficaNISECI, RiferimentoNISECI, RisultatoNISECI, ValoriIntermediNISECI,
+};
 use esox::engines::hfbi::full::{calculate_hfbi, calculate_stato_ecologico_hfbi};
 use esox::engines::niseci::full::{
     calculate_niseci, calculate_rqe_niseci, calculate_stato_ecologico_niseci,
@@ -264,13 +266,14 @@ impl OutputController {
                     );
 
                     //This logs to stdout
-                    intermediates.log();
+                    println!("{}", intermediates);
 
                     self.add_console_message(state, format!("{intermediates}"));
 
                     self.log_niseci_intermediates(
                         locale,
                         &intermediates,
+                        &riferimento,
                         &state
                             .fileinput_model
                             .get_riferimento_path()
@@ -345,6 +348,7 @@ impl OutputController {
         &self,
         locale: Localize,
         intermediates: &ValoriIntermediNISECI,
+        riferimento: &RiferimentoNISECI,
         ref_filename: &Path,
         station_code: &str,
     ) {
@@ -368,7 +372,8 @@ impl OutputController {
                     Localize::Italian => false,
                     Localize::International => true,
                 };
-                let string_representation = intermediates.to_csv(comma_csv_delimiter);
+                let string_representation =
+                    intermediates.to_csv_joined(riferimento, comma_csv_delimiter);
                 let write_result = writeln!(file, "{string_representation}");
                 match write_result {
                     Ok(_) => println!("Successfully wrote to file."),

--- a/src/controllers/output.rs
+++ b/src/controllers/output.rs
@@ -24,13 +24,25 @@ use crate::MainState;
 use dirs::document_dir;
 use esox::domain::hfbi::{AnagraficaHFBI, RisultatoHFBI, ValoriIntermediHFBI};
 use esox::domain::index::Indice;
-use esox::domain::niseci::{
-    AnagraficaNISECI, RiferimentoNISECI, RisultatoNISECI, ValoriIntermediNISECI,
+use esox::domain::niseci::{AnagraficaNISECI, RiferimentoNISECI};
+
+#[cfg(not(feature = "lessclone"))]
+use esox::{
+    domain::niseci::{RisultatoNISECI, ValoriIntermediNISECI},
+    engines::niseci::full::{
+        calculate_niseci, calculate_rqe_niseci, calculate_stato_ecologico_niseci,
+    },
 };
+
+#[cfg(feature = "lessclone")]
+use esox::{
+    domain::niseci::lessclone::{RisultatoNISECI, ValoriIntermediNISECI},
+    engines::niseci::full::lessclone::{
+        calculate_niseci, calculate_rqe_niseci, calculate_stato_ecologico_niseci,
+    },
+};
+
 use esox::engines::hfbi::full::{calculate_hfbi, calculate_stato_ecologico_hfbi};
-use esox::engines::niseci::full::{
-    calculate_niseci, calculate_rqe_niseci, calculate_stato_ecologico_niseci,
-};
 use raylib::RaylibHandle;
 use std::fs::{create_dir, OpenOptions};
 use std::io::Write;

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -350,7 +350,7 @@ pub(crate) fn run_headless(do_niseci: bool, has_headers: bool, args: &[String]) 
                     let stato_eco_niseci =
                         calculate_stato_ecologico_niseci(niseci, &anagrafica.area);
 
-                    intermediates.log();
+                    println!("{}", intermediates);
                     match niseci {
                         Some(val) => {
                             println!("NISECI: {val}");

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -34,14 +34,28 @@ use esox::domain::hfbi::{
 };
 use esox::domain::location::Location;
 use esox::domain::niseci::{
-    AnagraficaNISECI, AreaNISECI, CampionamentoNISECI, ComunitaNISECI, IdroEcoRegioneNISECI,
-    RiferimentoNISECI, RisultatoNISECI, TipoComunitaNISECI,
+    AnagraficaNISECI, AreaNISECI, ComunitaNISECI, IdroEcoRegioneNISECI, RiferimentoNISECI,
+    TipoComunitaNISECI,
 };
+
+#[cfg(not(feature = "lessclone"))]
+use esox::{
+    domain::niseci::{CampionamentoNISECI, RisultatoNISECI},
+    engines::niseci::full::{
+        calculate_niseci, calculate_rqe_niseci, calculate_stato_ecologico_niseci,
+    },
+};
+
+#[cfg(feature = "lessclone")]
+use esox::{
+    domain::niseci::lessclone::{CampionamentoNISECI, RisultatoNISECI},
+    engines::niseci::full::lessclone::{
+        calculate_niseci, calculate_rqe_niseci, calculate_stato_ecologico_niseci,
+    },
+};
+
 use esox::domain::posf32::PositiveF32;
 use esox::engines::hfbi::full::{calculate_hfbi, calculate_stato_ecologico_hfbi};
-use esox::engines::niseci::full::{
-    calculate_niseci, calculate_rqe_niseci, calculate_stato_ecologico_niseci,
-};
 use std::path::PathBuf;
 
 pub(crate) fn f_value_usage() {
@@ -278,11 +292,7 @@ pub(crate) fn run_headless(do_niseci: bool, has_headers: bool, args: &[String]) 
 
         let mut anagrafica_failed = false;
         let mut anagrafica = AnagraficaNISECI::new(
-            ComunitaNISECI::new(
-                TipoComunitaNISECI::Redatta,
-                None,
-                None,
-            ),
+            ComunitaNISECI::new(TipoComunitaNISECI::Redatta, None, None),
             "foo".to_string(),
             "foo".to_string(),
             AreaNISECI::Alpina,

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -278,11 +278,11 @@ pub(crate) fn run_headless(do_niseci: bool, has_headers: bool, args: &[String]) 
 
         let mut anagrafica_failed = false;
         let mut anagrafica = AnagraficaNISECI::new(
-            ComunitaNISECI {
-                tipo: TipoComunitaNISECI::Redatta,
-                fonte: None,
-                numero_protocollo: None,
-            },
+            ComunitaNISECI::new(
+                TipoComunitaNISECI::Redatta,
+                None,
+                None,
+            ),
             "foo".to_string(),
             "foo".to_string(),
             AreaNISECI::Alpina,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -46,6 +46,7 @@ pub(crate) const _COMMIT_HASH: &str = env!("COMMIT_HASH");
 pub(crate) const COMMIT_HASH_PLUS: &str = env!("COMMIT_HASH_PLUS");
 pub(crate) const BUILD_DATE: &str = env!("BUILD_DATE");
 pub(crate) const RFD_BACKEND: &str = env!("RFD_BACKEND");
+pub(crate) const ESOX_LESSCLONE_BACKEND: &str = env!("ESOX_LESSCLONE_BACKEND");
 
 use chrono::{Datelike, Local};
 use raylib::math::Rectangle;

--- a/src/core/pdf/mod.rs
+++ b/src/core/pdf/mod.rs
@@ -18,9 +18,19 @@
 use crate::app::core::{CISBA_LOGO_DATA, PROJECT_LOGO_DATA, PROJECT_LOGO_NAME_DATA};
 use crate::core::BUILD_DATE;
 use esox::domain::hfbi::{AnagraficaHFBI, RisultatoHFBI};
-use esox::domain::niseci::{AnagraficaNISECI, RiferimentoNISECI, RisultatoNISECI};
+use esox::domain::niseci::{AnagraficaNISECI, RiferimentoNISECI};
+
+#[cfg(feature = "lessclone")]
+use esox::{
+    domain::niseci::lessclone::RisultatoNISECI,
+    engines::niseci::full::lessclone::calculate_stato_ecologico_niseci,
+};
+#[cfg(not(feature = "lessclone"))]
+use esox::{
+    domain::niseci::RisultatoNISECI, engines::niseci::full::calculate_stato_ecologico_niseci,
+};
+
 use esox::engines::hfbi::full::calculate_stato_ecologico_hfbi;
-use esox::engines::niseci::full::calculate_stato_ecologico_niseci;
 use miniz_oxide::deflate::{compress_to_vec_zlib, CompressionLevel};
 use pdf_writer::{Chunk, Content, Filter, Finish, Name, Pdf, Rect, Ref, Str};
 use png::Decoder;

--- a/src/views/home.rs
+++ b/src/views/home.rs
@@ -16,7 +16,7 @@
 */
 use crate::app::core::{Action, Action::*};
 use crate::app::model::Model;
-use crate::core::{RFD_BACKEND, SHORT_PROJECT_VERSION};
+use crate::core::{ESOX_LESSCLONE_BACKEND, RFD_BACKEND, SHORT_PROJECT_VERSION};
 use crate::views::{propheight, propwidth, rrect, View};
 use crate::MainState;
 use raylib::color::Color;
@@ -98,6 +98,12 @@ impl View for HomeView {
             std::env::consts::OS
         );
         let label_rfd_backend_txt = format!("rfd backend:    {}", RFD_BACKEND);
+        let label_esox_backend_txt = format!(
+            "Using esox v{}, backend: {}",
+            esox::meta::version(),
+            ESOX_LESSCLONE_BACKEND
+        );
+
         let label_version_txt_bounds = main_state.current_font.measure_text(
             &label_version_txt,
             main_state.current_font_height as f32,
@@ -113,20 +119,33 @@ impl View for HomeView {
             main_state.current_font_height as f32,
             main_state.default_txt_spacing as f32,
         );
+        let label_esox_backend_txt_bounds = main_state.current_font.measure_text(
+            &label_esox_backend_txt,
+            main_state.current_font_height as f32,
+            main_state.default_txt_spacing as f32,
+        );
         let labels_width = propwidth(d, 25)
             + max(
                 max(
-                    label_version_txt_bounds.x as i32,
-                    label_target_txt_bounds.x as i32,
+                    max(
+                        label_version_txt_bounds.x as i32,
+                        label_target_txt_bounds.x as i32,
+                    ),
+                    label_rfd_backend_txt_bounds.x as i32,
                 ),
-                label_rfd_backend_txt_bounds.x as i32,
+                label_esox_backend_txt_bounds.x as i32,
             );
         let labels_x = (d.get_screen_width() - labels_width) / 2;
         let labels_y =
             logo_name_texture_target_y + logo_name_texture_target_height + propheight(d, 50);
         let labels_height = propheight(d, 25);
 
-        let labels: Vec<String> = vec![label_version_txt, label_target_txt, label_rfd_backend_txt];
+        let labels: Vec<String> = vec![
+            label_version_txt,
+            label_target_txt,
+            label_rfd_backend_txt,
+            label_esox_backend_txt,
+        ];
 
         for (i, label) in labels.iter().enumerate() {
             d.gui_label(

--- a/src/views/selezione_info_aggiuntive.rs
+++ b/src/views/selezione_info_aggiuntive.rs
@@ -719,11 +719,11 @@ impl View for SelezioneInfoAggiuntiveView {
                         }
                         _ => {}
                     }
-                    let comunita = ComunitaNISECI {
-                        tipo: tipo_comunita,
-                        fonte: opt_fonte,
-                        numero_protocollo: opt_num_protocollo,
-                    };
+                    let comunita = ComunitaNISECI::new(
+                        tipo_comunita,
+                        opt_fonte,
+                        opt_num_protocollo,
+                    );
                     let area = match <AreaNISECI as TryFrom<i32>>::try_from(
                         self.combobox_area_niseci_value,
                     ) {

--- a/src/views/selezione_info_aggiuntive.rs
+++ b/src/views/selezione_info_aggiuntive.rs
@@ -719,11 +719,8 @@ impl View for SelezioneInfoAggiuntiveView {
                         }
                         _ => {}
                     }
-                    let comunita = ComunitaNISECI::new(
-                        tipo_comunita,
-                        opt_fonte,
-                        opt_num_protocollo,
-                    );
+                    let comunita =
+                        ComunitaNISECI::new(tipo_comunita, opt_fonte, opt_num_protocollo);
                     let area = match <AreaNISECI as TryFrom<i32>>::try_from(
                         self.combobox_area_niseci_value,
                     ) {


### PR DESCRIPTION
### Added

- Add `lessclone` feature, enabled by default
  - Improves performance significantly

### Changed

- Avoid usage of deprecated reexports
  - `esox::domani::niseci::ValoriIntermediNISECI::to_csv` -> `esox::domani::niseci::ValoriIntermediNISECI::to_csv_joined`
  - `esox::domani::niseci::ValoriIntermediNISECI::log`
- Avoid usage of deprecated fields
  - `esox::domani::niseci::ComunitaNISECI`
- Bump `esox` to `0.1.6`
  - Improves performance for all builds
  - More improvements when building with `lessclone` feature
  - Changelog: [link](https://github.com/JGGR/esox/releases/tag/0.1.6)
  - Closes #22 