### PR TITLE
DRAFT: Try forked raylib-rs for gui_load_style_from_memory()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+### Changed
+
+- Try forked `raylib-rs` in `Cargo.toml`:
+  - `repo = git@github.com/jgabaut/raylib-rs.git`
+  - `branch = work/gui_load_style_from_memory`
+  - Allows proper usage of embedded styles
+- Drop `uuid` dep
+
 ## [0.1.4] - 2026-04-30
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "atk-sys"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,7 +275,6 @@ dependencies = [
  "png",
  "raylib",
  "rfd",
- "uuid",
 ]
 
 [[package]]
@@ -302,12 +295,6 @@ dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.9",
 ]
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gdk-pixbuf-sys"
@@ -348,19 +335,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -432,15 +406,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -475,21 +440,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -531,12 +488,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -828,12 +779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,7 +787,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 [[package]]
 name = "raylib"
 version = "5.7.0"
-source = "git+https://github.com/jgabaut/raylib-rs.git#c574449e65d698d7bee1e7d623726f83947a2c13"
+source = "git+https://github.com/jgabaut/raylib-rs.git?branch=work%2Fgui_load_style_from_memory#d250161b8878931d3573157a72f7aed23fb380bb"
 dependencies = [
  "glam",
  "paste",
@@ -854,7 +799,7 @@ dependencies = [
 [[package]]
 name = "raylib-sys"
 version = "5.7.0"
-source = "git+https://github.com/jgabaut/raylib-rs.git#c574449e65d698d7bee1e7d623726f83947a2c13"
+source = "git+https://github.com/jgabaut/raylib-rs.git?branch=work%2Fgui_load_style_from_memory#d250161b8878931d3573157a72f7aed23fb380bb"
 dependencies = [
  "bindgen",
  "cc",
@@ -868,7 +813,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "libredox",
  "thiserror",
 ]
@@ -948,12 +893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "seq-macro"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,19 +926,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
 ]
 
 [[package]]
@@ -1120,23 +1046,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "uuid"
-version = "1.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
-dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,24 +1056,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1222,40 +1113,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -1386,97 +1243,3 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 [[package]]
 name = "raylib"
 version = "5.7.0"
-source = "git+https://github.com/raylib-rs/raylib-rs.git#c7227f666187ab8c35be7162ced718205489aec2"
+source = "git+https://github.com/jgabaut/raylib-rs.git#c574449e65d698d7bee1e7d623726f83947a2c13"
 dependencies = [
  "glam",
  "paste",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "raylib-sys"
 version = "5.7.0"
-source = "git+https://github.com/raylib-rs/raylib-rs.git#c7227f666187ab8c35be7162ced718205489aec2"
+source = "git+https://github.com/jgabaut/raylib-rs.git#c574449e65d698d7bee1e7d623726f83947a2c13"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ locale_config = "0.3.0"
 miniz_oxide = "0.9.1"
 pdf-writer = "0.14.0"
 png = "0.18.1"
-raylib = { git = "https://github.com/raylib-rs/raylib-rs.git", features = [
+raylib = { git = "https://github.com/jgabaut/raylib-rs.git", features = [
     "raygui",
 ] }
 rfd = { version = "0.17.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,7 @@ locale_config = "0.3.0"
 miniz_oxide = "0.9.1"
 pdf-writer = "0.14.0"
 png = "0.18.1"
-raylib = { git = "https://github.com/jgabaut/raylib-rs.git", features = [
+raylib = { git = "https://github.com/jgabaut/raylib-rs.git", branch = "work/gui_load_style_from_memory", features = [
     "raygui",
 ] }
 rfd = { version = "0.17.2", default-features = false }
-uuid = { version = "1.23.1", features = ["v4"] }

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -26,10 +26,6 @@ use raylib::consts::GuiControlProperty::TEXT_COLOR_NORMAL;
 use raylib::consts::GuiDefaultProperty::{BACKGROUND_COLOR, TEXT_SIZE, TEXT_SPACING};
 use raylib::consts::KeyboardKey::*;
 use raylib::RaylibHandle;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-use uuid::Uuid;
 
 pub(crate) fn update_main(
     rl: &mut RaylibHandle,
@@ -135,6 +131,7 @@ pub(crate) fn update_main(
     }
 }
 
+/*
 fn write_temp_style_file(data: &[u8]) -> Result<(String, PathBuf), Box<dyn std::error::Error>> {
     // We employ a UUID to randomise the filename, as required
     // to avoid insecure temporary files vulnerabilities
@@ -149,11 +146,17 @@ fn write_temp_style_file(data: &[u8]) -> Result<(String, PathBuf), Box<dyn std::
     let string = String::from(temp_path.to_string_lossy());
     Ok((string, temp_path))
 }
+*/
 
 fn load_style_from_memory(rl: &mut RaylibHandle, data: &[u8]) {
+    /*
     // Al momento, raylib-rs non espone una funzione gui_load_style_from_memory().
     // Qui simuliamo la disponibilità runtime di un file .rgs, partendo dai byte
     // di include_bytes!(). Non la migliore idea, ma sembra funzionare.
+
+    // At this time, raylib-rs does not expose fn gui_load_style_from_memory().
+    // Here we simulate runtime availability of a binary .rgs file, starting from
+    // bytes here provided with include_bytes!(). Not the best idea, but it seems to work.
 
     // Write the data to a temporary file
     let (temp_file_cstring, temp_file_path) =
@@ -164,6 +167,12 @@ fn load_style_from_memory(rl: &mut RaylibHandle, data: &[u8]) {
 
     // Remove the temp file after loading the style
     std::fs::remove_file(temp_file_path).expect("Failed to delete temp style file");
+    */
+
+    // Load the style
+    // This API is not currently exposed by raygui, but
+    // gui_load_style() still reaches the same code under the ffi.
+    rl.gui_load_style_from_memory(data);
 }
 
 impl GuiTheme {

--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -131,40 +131,20 @@ pub(crate) fn update_main(
     }
 }
 
-/*
-fn write_temp_style_file(data: &[u8]) -> Result<(String, PathBuf), Box<dyn std::error::Error>> {
-    // We employ a UUID to randomise the filename, as required
-    // to avoid insecure temporary files vulnerabilities
-    // See: https://doc.rust-lang.org/nightly/std/env/fn.temp_dir.html
-    let mut temp_path = std::env::temp_dir();
-    let id = Uuid::new_v4();
-    temp_path.push(format!("{}.rgs", id));
-
-    let mut file = File::create(&temp_path)?;
-    file.write_all(data)?;
-
-    let string = String::from(temp_path.to_string_lossy());
-    Ok((string, temp_path))
-}
-*/
-
 fn load_style_from_memory(rl: &mut RaylibHandle, data: &[u8]) {
     /*
-    // Al momento, raylib-rs non espone una funzione gui_load_style_from_memory().
-    // Qui simuliamo la disponibilità runtime di un file .rgs, partendo dai byte
-    // di include_bytes!(). Non la migliore idea, ma sembra funzionare.
-
-    // At this time, raylib-rs does not expose fn gui_load_style_from_memory().
+    // At the original time of writing this, raylib-rs does not expose
+    // pub fn gui_load_style_from_memory().
     // Here we simulate runtime availability of a binary .rgs file, starting from
     // bytes here provided with include_bytes!(). Not the best idea, but it seems to work.
-
+    //
     // Write the data to a temporary file
     let (temp_file_cstring, temp_file_path) =
         write_temp_style_file(data).expect("Failed to write temp style file");
-
+    //
     // Load the style
     rl.gui_load_style(temp_file_cstring.as_str());
-
+    //
     // Remove the temp file after loading the style
     std::fs::remove_file(temp_file_path).expect("Failed to delete temp style file");
     */


### PR DESCRIPTION
## _*WIP: See the diff and linked items.*_


See:
- https://github.com/raylib-rs/raylib-rs/pull/296
- https://github.com/raysan5/raygui/pull/548
- https://github.com/raysan5/raygui/pull/549

### Changed

- Drop `uuid` dep
- WIP: Try forked `raylib-rs` in `Cargo.toml`:
  - `repo = git@github.com/jgabaut/raylib-rs.git`
  - `branch = work/gui_load_style_from_memory`
  - Allows proper usage of embedded styles